### PR TITLE
Add ability to override start on and stop on directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.5
+
+* Added support for setting the `start on` and `stop on` directives.
+
 ## Version 0.1.4
 
 * Added support/testing for setting service environment variables, closes #3 (thanks @klamontagne)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Resource attributes:: `service_desc` , `exec` , `run_user` , `run_group`
       run_group "nobody"
       action :create                  # can also :enable and :start here, use array
     end
-    
+
 ** Service with arguments or environment variables **
 
     service_factory "my_service" do
@@ -66,7 +66,7 @@ Resource attributes:: `service_desc` , `exec` , `run_user` , `run_group`
       run_group "nobody"
       action :create
     end
-    
+
 ** Forked service **
 
 It's really import to set the proper flag if the service forks.
@@ -81,7 +81,7 @@ It's really import to set the proper flag if the service forks.
       run_group "nobody"
       action :create
     end
-    
+
 ** Notifications **
 
 The service_factory resource can receive all standard service signals. It also creates a stock service resource you can notify as well.
@@ -89,7 +89,7 @@ The service_factory resource can receive all standard service signals. It also c
     some_resource "abc" do
       notifies :start, "service_factory[my_service]"
     end
-    
+
     some_resource "abc" do
       notifies :start, "service[my_service]"
     end
@@ -180,6 +180,12 @@ The service_factory resource can receive all standard service signals. It also c
 
     :path_variables = Hash.new
         Additional variables injectable into path strings.
+
+    :start_on = "start on runlevel [35]"
+        Override the default start on directive for upstart service.
+
+    :stop_on = "stop on starting rc RUNLEVEL=[016]"
+        Override the default stop on directive for upstart service.
 
 
 # Recipes

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ license          "Apache License, Version 2.0"
 description      "LWRPs to generate services using native system features and service managers. (SysV, Upstart, ...)"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 
-version          "0.1.4"
+version          "0.1.5"
 
 depends          "unix_bin", ">= 0.2.7"
 depends          "resource_masher", ">= 0.10.0"

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -70,3 +70,6 @@ attribute :run_group, :kind_of => String, :required => true
 
 attribute :env_variables, :kind_of => Hash, :default => Hash.new
 attribute :path_variables, :kind_of => Hash, :default => Hash.new
+
+atrribute :start_on, :kind_of => String, :default => 'runlevel [35]'
+atrribute :stop_on, :kind_of => String, :default => 'starting rc RUNLEVEL=[016]'

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -71,5 +71,5 @@ attribute :run_group, :kind_of => String, :required => true
 attribute :env_variables, :kind_of => Hash, :default => Hash.new
 attribute :path_variables, :kind_of => Hash, :default => Hash.new
 
-atrribute :start_on, :kind_of => String, :default => 'runlevel [35]'
-atrribute :stop_on, :kind_of => String, :default => 'starting rc RUNLEVEL=[016]'
+attribute :start_on, :kind_of => String, :default => 'runlevel [35]'
+attribute :stop_on, :kind_of => String, :default => 'starting rc RUNLEVEL=[016]'

--- a/templates/default/upstart.service.erb
+++ b/templates/default/upstart.service.erb
@@ -8,8 +8,19 @@ env LCK_FILE=<%= @lock_file %>
 env LOG_FILE=<%= @log_file %>
 env RUN_USER=<%= @run_user %>
 
+# Service start dependencies/directives
+<% unless @start_on.nil? -%>
 start on runlevel [35]
+<% else -%>
+start on <%= @start_on %>
+<% end -%>
+
+# Service stop dependencies/directives
+<% unless @stop_on.nil? -%>
 stop on starting rc RUNLEVEL=[016]  # ensures long kill timeout's are enforced
+<% else -%>
+stop on <%= @stop_on %>
+<% end -%>
 kill timeout <%= @kill_timeout %>
 <% unless @supports_reload -%>
 respawn

--- a/templates/default/upstart.service.erb
+++ b/templates/default/upstart.service.erb
@@ -8,19 +8,8 @@ env LCK_FILE=<%= @lock_file %>
 env LOG_FILE=<%= @log_file %>
 env RUN_USER=<%= @run_user %>
 
-# Service start dependencies/directives
-<% unless @start_on.nil? -%>
-start on runlevel [35]
-<% else -%>
 start on <%= @start_on %>
-<% end -%>
-
-# Service stop dependencies/directives
-<% unless @stop_on.nil? -%>
-stop on starting rc RUNLEVEL=[016]  # ensures long kill timeout's are enforced
-<% else -%>
 stop on <%= @stop_on %>
-<% end -%>
 kill timeout <%= @kill_timeout %>
 <% unless @supports_reload -%>
 respawn


### PR DESCRIPTION
This is a simple fix that allows the user to specify an override for the `start on` and `stop on` directives. 
- [Upstart Docs](http://upstart.ubuntu.com/cookbook/#ordering)
- Issue: #1 
- Existing users will continue to work as they used to.
